### PR TITLE
Enhance DOI resolution using search_download titles

### DIFF
--- a/download_papers.py
+++ b/download_papers.py
@@ -31,6 +31,7 @@ class DownloadResult:
     ratio: float | None
     file_path: str | None
     error: str | None = None
+    doi: str | None = None
 
 
 def _looks_like_author_line(line: str) -> bool:
@@ -134,20 +135,73 @@ def download_papers(
             )
             continue
 
-        best_match = max(
-            papers,
-            key=lambda paper: _fuzzy_ratio(title, paper.get("name", ""))
-        )
-        ratio = _fuzzy_ratio(title, best_match.get("name", ""))
+        ranked_candidates = []
+        for paper in papers:
+            paper_title = paper.get("name", "")
+            ranked_candidates.append(
+                (paper, _fuzzy_ratio(title, paper_title))
+            )
 
-        if ratio < min_ratio:
+        ranked_candidates.sort(key=lambda item: item[1], reverse=True)
+
+        matched_paper = None
+        matched_ratio = None
+        matched_doi = None
+        captcha_failure = False
+
+        for index, (paper, ratio) in enumerate(ranked_candidates):
+            if ratio < min_ratio:
+                break
+
+            identifier = paper.get("url", "")
+
+            try:
+                doi = None
+                if index == 0:
+                    doi, _ = scihub.search_for_doi(
+                        paper.get("name", ""), limit=search_limit
+                    )
+                if not doi:
+                    doi = scihub.resolve_identifier_to_doi(identifier)
+            except CaptchaNeedException as exc:
+                results.append(
+                    DownloadResult(
+                        title,
+                        paper.get("name"),
+                        ratio,
+                        None,
+                        str(exc),
+                    )
+                )
+                captcha_failure = True
+                break
+
+            if doi:
+                matched_paper = paper
+                matched_ratio = ratio
+                matched_doi = doi
+                break
+
+        if captcha_failure:
+            continue
+
+        if not matched_paper:
+            best_candidate = ranked_candidates[0][0] if ranked_candidates else {}
+            best_ratio = ranked_candidates[0][1] if ranked_candidates else None
+            error_message = "No viable search candidates"
+            if ranked_candidates:
+                if best_ratio is not None and best_ratio >= min_ratio:
+                    error_message = "Unable to resolve DOI from search results"
+                elif best_ratio is not None:
+                    error_message = f"Best match below threshold ({best_ratio:.2f} < {min_ratio})"
+
             results.append(
                 DownloadResult(
                     title,
-                    best_match.get("name"),
-                    ratio,
+                    best_candidate.get("name") if best_candidate else None,
+                    best_ratio,
                     None,
-                    f"Best match below threshold ({ratio:.2f} < {min_ratio})",
+                    error_message,
                 )
             )
             continue
@@ -155,25 +209,45 @@ def download_papers(
         filename = _sanitize_filename(title) + ".pdf"
         try:
             data = scihub.download(
-                best_match.get("url", ""),
+                matched_doi,
                 destination=output_dir,
                 path=filename,
             )
         except CaptchaNeedException as exc:
             results.append(
-                DownloadResult(title, best_match.get("name"), ratio, None, str(exc))
+                DownloadResult(
+                    title,
+                    matched_paper.get("name"),
+                    matched_ratio,
+                    None,
+                    str(exc),
+                    matched_doi,
+                )
             )
             continue
 
         if "err" in data:
             results.append(
-                DownloadResult(title, best_match.get("name"), ratio, None, data["err"])
+                DownloadResult(
+                    title,
+                    matched_paper.get("name"),
+                    matched_ratio,
+                    None,
+                    data["err"],
+                    matched_doi,
+                )
             )
             continue
 
         file_path = os.path.join(output_dir, filename)
         results.append(
-            DownloadResult(title, best_match.get("name"), ratio, file_path)
+            DownloadResult(
+                title,
+                matched_paper.get("name"),
+                matched_ratio,
+                file_path,
+                doi=matched_doi,
+            )
         )
 
     return results

--- a/scihub/scihub.py
+++ b/scihub/scihub.py
@@ -29,6 +29,7 @@ urllib3.disable_warnings()
 # constants
 SCHOLARS_BASE_URL = 'https://scholar.google.com/scholar'
 HEADERS = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:27.0) Gecko/20100101 Firefox/27.0'}
+DOI_PATTERN = re.compile(r"10\.\d{4,9}/[-._;()/:A-Z0-9]+", re.IGNORECASE)
 
 class SciHub(object):
     """
@@ -180,6 +181,62 @@ class SciHub(object):
                        % (identifier, url)
             }
 
+    def resolve_identifier_to_doi(self, identifier):
+        """
+        Try to resolve *identifier* to a DOI string.
+
+        The identifier can be a DOI, PMID, paywalled URL, or other link returned
+        from a Google Scholar search. If the identifier already looks like a DOI,
+        it is returned as-is. Otherwise, Sci-Hub is queried similarly to the
+        ``--search_download`` CLI flow and the returned HTML is scanned for a DOI.
+        """
+
+        doi = self._extract_doi(identifier)
+        if doi:
+            return doi
+
+        try:
+            response = self.sess.get(self.base_url + identifier, verify=False)
+        except requests.exceptions.RequestException:
+            return None
+
+        doi = self._extract_doi(response.url)
+        if doi:
+            return doi
+
+        soup = self._get_soup(response.content)
+
+        # Check obvious attributes first.
+        for tag in soup.find_all(True):
+            for attr in ("href", "src"):
+                value = tag.attrs.get(attr)
+                if not value:
+                    continue
+                doi = self._extract_doi(value)
+                if doi:
+                    return doi
+
+        text = soup.get_text(" ", strip=True)
+        return self._extract_doi(text)
+
+    def search_for_doi(self, query, limit=10):
+        """Search Google Scholar for *query* and attempt to resolve a DOI."""
+
+        results = self.search(query, limit)
+        if 'err' in results:
+            message = results['err']
+            if isinstance(message, str) and 'captcha' in message.lower():
+                raise CaptchaNeedException(message)
+            logger.info('Search failed for %s: %s', query, message)
+            return None, None
+        papers = results.get('papers', [])
+        for paper in papers:
+            identifier = paper.get('url', '')
+            doi = self.resolve_identifier_to_doi(identifier)
+            if doi:
+                return doi, paper
+        return None, None
+
     def _get_direct_url(self, identifier):
         """
         Finds the direct source url for a given identifier.
@@ -234,7 +291,7 @@ class SciHub(object):
 
     def _generate_name(self, res):
         """
-        Generate unique filename for paper. Returns a name by calcuating 
+        Generate unique filename for paper. Returns a name by calcuating
         md5 hash of file contents, then appending the last 20 characters
         of the url which typically provides a good paper identifier.
         """
@@ -242,6 +299,17 @@ class SciHub(object):
         name = re.sub('#view=(.+)', '', name)
         pdf_hash = hashlib.md5(res.content).hexdigest()
         return '%s-%s' % (pdf_hash, name[-20:])
+
+    def _extract_doi(self, text):
+        """Return the first DOI detected in *text*, or ``None``."""
+
+        if not text:
+            return None
+
+        match = DOI_PATTERN.search(text)
+        if match:
+            return match.group(0).rstrip(').,;')
+        return None
 
 class CaptchaNeedException(Exception):
     pass


### PR DESCRIPTION
## Summary
- rank fuzzy-matched search results and resolve DOIs via Sci-Hub search-download logic before invoking downloads, while storing the DOI alongside each result
- add DOI parsing utilities to the SciHub client, including identifier resolution, Google Scholar backed lookup, and captcha-aware error handling

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d44ceef5048328abedd463e2ced779